### PR TITLE
[M@S Usability] Enable search by Fragment Title (cardTitle field)

### DIFF
--- a/studio/src/common/components/mas-search-and-filters.js
+++ b/studio/src/common/components/mas-search-and-filters.js
@@ -311,12 +311,14 @@ class MasSearchAndFilters extends LitElement {
                     const path = (fragment.path || '').toLowerCase();
                     const productTag = fragment.tags?.find(({ id }) => id?.startsWith('mas:product_code/'))?.title || '';
                     const offerId = fragment.offerData?.offerId || '';
+                    const cardTitle = fragment.fields?.find((field) => field.name === 'cardTitle')?.values?.[0] || '';
                     if (
                         !title.includes(query) &&
                         !studioPath.includes(query) &&
                         !path.includes(query) &&
                         !productTag.toLowerCase().includes(query) &&
-                        !offerId.toLowerCase().includes(query)
+                        !offerId.toLowerCase().includes(query) &&
+                        !cardTitle.toLowerCase().includes(query)
                     ) {
                         return false;
                     }

--- a/studio/test/translation/mas-search-and-filters.test.js
+++ b/studio/test/translation/mas-search-and-filters.test.js
@@ -378,6 +378,34 @@ describe('MasSearchAndFilters', () => {
             expect(Store.translationProjects.displayCards.get().length).to.equal(1);
         });
 
+        it('should filter fragments by Fragment Title field (title property)', async () => {
+            Store.translationProjects.allCards.set([
+                createMockFragment({ title: 'Adobe Firefly Pro Plan' }),
+                createMockFragment({ title: 'Adobe Photoshop Pro' }),
+                createMockFragment({ title: 'Standard Illustrator' }),
+            ]);
+            const el = await fixture(html`<mas-search-and-filters type="cards"></mas-search-and-filters>`);
+            el.searchQuery = 'Firefly Pro';
+            await el.updateComplete;
+            const result = Store.translationProjects.displayCards.get();
+            expect(result.length).to.equal(1);
+            expect(result[0].title).to.equal('Adobe Firefly Pro Plan');
+        });
+
+        it('should filter fragments by partial Fragment Title match', async () => {
+            Store.translationProjects.allCards.set([
+                createMockFragment({ title: 'CC Catalog Merch Card: Adobe Embedded Print Engine: Individuals: default' }),
+                createMockFragment({ title: 'CC Plans Merch Card: Adobe Photoshop: Team: promo' }),
+                createMockFragment({ title: 'Regular Card without match' }),
+            ]);
+            const el = await fixture(html`<mas-search-and-filters type="cards"></mas-search-and-filters>`);
+            el.searchQuery = 'Embedded Print Engine';
+            await el.updateComplete;
+            const result = Store.translationProjects.displayCards.get();
+            expect(result.length).to.equal(1);
+            expect(result[0].title).to.include('Embedded Print Engine');
+        });
+
         it('should filter placeholders by key', async () => {
             Store.translationProjects.allPlaceholders.set([
                 createMockPlaceholder({ key: 'buy-now', value: 'Buy Now' }),

--- a/studio/test/translation/mas-search-and-filters.test.js
+++ b/studio/test/translation/mas-search-and-filters.test.js
@@ -472,6 +472,57 @@ describe('MasSearchAndFilters', () => {
             expect(result.length).to.equal(1);
             expect(result[0].key).to.equal('cta-promo');
         });
+
+        it('should filter cards by cardTitle field', async () => {
+            Store.translationProjects.allCards.set([
+                createMockFragment({
+                    title: 'Internal Title 1',
+                    fields: [{ name: 'cardTitle', values: ['Firefly Pro'] }],
+                }),
+                createMockFragment({
+                    title: 'Internal Title 2',
+                    fields: [{ name: 'cardTitle', values: ['Photoshop'] }],
+                }),
+            ]);
+            const el = await fixture(html`<mas-search-and-filters type="cards"></mas-search-and-filters>`);
+            el.searchQuery = 'Firefly';
+            await el.updateComplete;
+            const result = Store.translationProjects.displayCards.get();
+            expect(result.length).to.equal(1);
+            expect(result[0].fields.find((f) => f.name === 'cardTitle').values[0]).to.equal('Firefly Pro');
+        });
+
+        it('should filter cards by cardTitle case-insensitively', async () => {
+            Store.translationProjects.allCards.set([
+                createMockFragment({
+                    title: 'Internal Title',
+                    fields: [{ name: 'cardTitle', values: ['Adobe Creative Cloud'] }],
+                }),
+                createMockFragment({
+                    title: 'Another Title',
+                    fields: [{ name: 'cardTitle', values: ['Something Else'] }],
+                }),
+            ]);
+            const el = await fixture(html`<mas-search-and-filters type="cards"></mas-search-and-filters>`);
+            el.searchQuery = 'creative';
+            await el.updateComplete;
+            const result = Store.translationProjects.displayCards.get();
+            expect(result.length).to.equal(1);
+            expect(result[0].fields.find((f) => f.name === 'cardTitle').values[0]).to.equal('Adobe Creative Cloud');
+        });
+
+        it('should handle fragments without cardTitle field gracefully', async () => {
+            Store.translationProjects.allCards.set([
+                createMockFragment({ title: 'Photoshop card', fields: [] }),
+                createMockFragment({ title: 'Another card', fields: [{ name: 'variant', values: ['plans'] }] }),
+            ]);
+            const el = await fixture(html`<mas-search-and-filters type="cards"></mas-search-and-filters>`);
+            el.searchQuery = 'Photoshop';
+            await el.updateComplete;
+            const result = Store.translationProjects.displayCards.get();
+            expect(result.length).to.equal(1);
+            expect(result[0].title).to.equal('Photoshop card');
+        });
     });
 
     describe('filter extraction', () => {


### PR DESCRIPTION
## Root Cause
The search functionality in M@S Studio was not including the `cardTitle` field when filtering fragments. The search was checking:
- `fragment.title` (internal AEM title)
- `studioPath`
- `path`
- `productTag`
- `offerId`

However, it was missing the `cardTitle` field, which is the user-facing title displayed on fragments (e.g., "Firefly Pro", "Adobe Creative Cloud"). This meant users couldn't search for fragments using the card titles they see in the UI.

## Summary of Changes
- **Updated `mas-search-and-filters.js`**: Added `cardTitle` field extraction and search matching
  - Extract cardTitle from fragment fields: `fragment.fields?.find((field) => field.name === 'cardTitle')?.values?.[0]`
  - Added case-insensitive matching for cardTitle in search query
  - Gracefully handles fragments without cardTitle field
  
- **Added comprehensive tests** in `mas-search-and-filters.test.js`:
  - Test searching cards by cardTitle field
  - Test case-insensitive cardTitle search
  - Test graceful handling of fragments without cardTitle field

## Test Plan
1. ✅ Verify syntax is valid (ran `node -c` on modified files)
2. ✅ Added 3 new test cases covering:
   - Basic cardTitle search functionality
   - Case-insensitive search
   - Missing field handling
3. Manual testing should verify:
   - Search for "Firefly Pro" in M@S Studio returns fragments with that cardTitle
   - Search works in both Fragments section and Translations section "Select items" modals
   - Case-insensitive search works (e.g., "firefly" matches "Firefly Pro")
   - Fragments without cardTitle still work with other search fields

Fixes MWPW-190535