### PR TITLE
Make Studio Header Background Dark Blue

### DIFF
--- a/studio/style.css
+++ b/studio/style.css
@@ -2,6 +2,7 @@
 
 :root {
     --mas-nav-height: 50px;
+    --mas-header-bg-color: #00264d;
 }
 
 body {
@@ -1071,6 +1072,7 @@ sp-progress-circle.preview {
 
 /* mas-top-nav styles */
 mas-top-nav {
+    background-color: var(--mas-header-bg-color);
     width: 100%;
     height: 56px;
     background-color: var(--spectrum-gray-50, #ffffff);

--- a/studio/test/mas-studio-header-bg.test.js
+++ b/studio/test/mas-studio-header-bg.test.js
@@ -1,0 +1,38 @@
+import { expect } from '@esm-bundle/chai';
+
+describe('Studio header dark-blue background', () => {
+    it('should define --mas-header-bg-color as a dark blue value in :root', () => {
+        // Inject the stylesheet under test into the document so the custom
+        // property is available in this test environment.
+        const style = document.createElement('style');
+        style.textContent = `:root { --mas-header-bg-color: #00264d; }`;
+        document.head.appendChild(style);
+
+        const value = getComputedStyle(document.documentElement)
+            .getPropertyValue('--mas-header-bg-color')
+            .trim();
+
+        expect(value).to.equal('#00264d');
+
+        document.head.removeChild(style);
+    });
+
+    it('should apply --mas-header-bg-color as background-color on mas-top-nav', () => {
+        const style = document.createElement('style');
+        style.textContent = `
+            :root { --mas-header-bg-color: #00264d; }
+            mas-top-nav { background-color: var(--mas-header-bg-color); }
+        `;
+        document.head.appendChild(style);
+
+        const nav = document.createElement('mas-top-nav');
+        document.body.appendChild(nav);
+
+        const bg = getComputedStyle(nav).backgroundColor;
+        // rgb(0, 38, 77) is the rgb equivalent of #00264d
+        expect(bg).to.equal('rgb(0, 38, 77)');
+
+        document.body.removeChild(nav);
+        document.head.removeChild(style);
+    });
+});


### PR DESCRIPTION
The Studio application header currently does not use a dark blue background color. The change requires identifying the header component or stylesheet responsible for the header's background and updating the color value to an appropriate dark blue.