### PR TITLE
Make Studio Header Background Dark Blue

### DIFF
--- a/studio/src/mas-top-nav.js
+++ b/studio/src/mas-top-nav.js
@@ -1,5 +1,5 @@
 import { ENVS, EnvColorCode, WCS_LANDSCAPE_DRAFT, WCS_LANDSCAPE_PUBLISHED, PAGE_NAMES } from './constants.js';
-import { LitElement, html, nothing } from 'lit';
+import { LitElement, html, nothing, css } from 'lit';
 import { keyed } from 'lit/directives/keyed.js';
 import { until } from 'lit/directives/until.js';
 import Store from './store.js';
@@ -11,6 +11,13 @@ import './mas-nav-folder-picker.js';
 import './mas-locale-picker.js';
 
 class MasTopNav extends LitElement {
+    static styles = css`
+        :host {
+            --studio-header-bg: #002B5C;
+            background-color: var(--studio-header-bg);
+        }
+    `;
+
     page = Store.page;
     inEdit = Store.fragments.inEdit;
     editorContext = Store.fragmentEditor.editorContext;

--- a/studio/test/mas-top-nav.test.js
+++ b/studio/test/mas-top-nav.test.js
@@ -7,7 +7,29 @@ import router from '../src/router.js';
 import { PAGE_NAMES, WCS_LANDSCAPE_DRAFT, WCS_LANDSCAPE_PUBLISHED } from '../src/constants.js';
 import { delay } from './utils.js';
 import '../src/swc.js';
-import '../src/mas-top-nav.js';
+import MasTopNav from '../src/mas-top-nav.js';
+
+describe('MasTopNav header background color', () => {
+    it('should define --studio-header-bg as #002B5C in static styles', () => {
+        const styleText = MasTopNav.styles
+            ? (Array.isArray(MasTopNav.styles)
+                ? MasTopNav.styles.map((s) => s.cssText).join('')
+                : MasTopNav.styles.cssText)
+            : '';
+        expect(styleText).to.include('--studio-header-bg');
+        expect(styleText).to.include('#002B5C');
+    });
+
+    it('should apply dark blue background-color via CSS variable', () => {
+        const styleText = MasTopNav.styles
+            ? (Array.isArray(MasTopNav.styles)
+                ? MasTopNav.styles.map((s) => s.cssText).join('')
+                : MasTopNav.styles.cssText)
+            : '';
+        expect(styleText).to.include('background-color');
+        expect(styleText).to.include('var(--studio-header-bg)');
+    });
+});
 
 describe('MasTopNav', () => {
     let sandbox;


### PR DESCRIPTION
The Studio application header currently does not use a dark blue background color. The change requires identifying the header component and applying a dark blue background style to it.