### PR TITLE
Add .fiesta/ harness contract for M@S

### DIFF
--- a/.fiesta/README.md
+++ b/.fiesta/README.md
@@ -1,0 +1,50 @@
+# `.fiesta/` — M@S's harness contract
+
+This folder is how M@S (Merch at Scale) drives the **fiesta** automation harness
+as a tenant. The harness reads these files at the pinned commit and holds no
+M@S-specific knowledge of its own — everything M@S-specific lives here.
+
+| File | What it declares |
+|------|------------------|
+| `manifest.yaml` | M@S's identity (`org`/`product`/`repo`) and which shared mental models the planner should use. |
+| `gates.yaml` | M@S's verification gates. When present, these **replace** the harness's built-in default set. |
+| `preview.yaml` | How to turn a branch + page into a live preview URL, for the visual gate. |
+| `workflows/*.yaml` | M@S workflows, composed from the harness's capability handlers. |
+
+## Gates
+
+`gates.yaml` declares four gates, mirroring what M@S CI enforces on a
+web-components PR:
+
+- **lint** — `npx eslint web-components studio`
+- **format** — `npx prettier --check .`
+- **unit-tests** — `npm test` (the Web Test Runner suite across workspaces; it
+  also enforces the ≥85% branch/statement coverage thresholds in
+  `web-test-runner.config.mjs`)
+- **visual** — screenshots a component demo page at two breakpoints and routes
+  the evidence to a human for sign-off
+
+There is no separate "component structure" gate: M@S enforces test co-location
+through the test runner's file globbing plus the coverage thresholds, so a
+component without a test fails the unit-tests gate already.
+
+## Preview
+
+`preview.yaml`'s `pin_pattern` substitutes `{branch}` and `{page}`. On Edge
+Delivery Services a branch is served at `<branch>--mas--<owner>.aem.page`.
+Two M@S specifics: feature branches must be named `MWPW-XXXXXX` (IMS auth), and
+authenticated surfaces (e.g. `/studio.html`) need IMS credentials — the
+component docs pages (e.g. `/web-components/docs/ccd.html`) render without auth.
+
+## Mental models
+
+`manifest.yaml`'s `mental_models.use` lists the models M@S selects by id. The
+selection is M@S's; the model content is shared and resolved from the registry
+at run time, so the same models are reused across products rather than copied
+into each repo.
+
+## Workflows
+
+`workflows/restyle-component.yaml` composes registered capability handlers
+(`codegen.generate` → `mock.approval`). The harness namespaces the id to
+`mas.restyle-component`.

--- a/.fiesta/gates.yaml
+++ b/.fiesta/gates.yaml
@@ -1,0 +1,45 @@
+# M@S verification gates.
+#
+# When this file is present the harness runs THESE gates in place of its
+# built-in default set. Each binds to a platform-owned template (command |
+# coverage | visual) and supplies the parameters; commands run in the worktree.
+#
+# These mirror what M@S CI enforces on a web-components PR: eslint, prettier,
+# the Web Test Runner unit suite (which also enforces the ≥85% coverage
+# thresholds in web-test-runner.config.mjs), plus a visual check of a component
+# demo page. Test co-location per component is enforced by the runner + coverage
+# thresholds, so there is no separate structure gate.
+gates:
+  lint:
+    template: command
+    name: ESLint (web-components, studio)
+    cmd: npx eslint web-components studio
+    blocking: true
+    failure_route: repair_loop
+
+  format:
+    template: command
+    name: Prettier formatting check
+    cmd: npx prettier --check .
+    blocking: true
+    failure_route: repair_loop
+
+  unit-tests:
+    template: command
+    name: Web Test Runner unit suite (with coverage thresholds)
+    cmd: npm test
+    timeout_s: 600
+    blocking: true
+    failure_route: repair_loop
+
+  visual:
+    template: visual
+    name: Visual evidence (CCD merch cards demo)
+    page: /web-components/docs/ccd.html
+    breakpoints: [900, 1200]
+    criteria: >-
+      The CCD merch cards render without layout breakage or overlapping elements
+      at each breakpoint, with correct spacing, price/text alignment, and
+      typography matching the intended design. No empty or error card states.
+    require_human: true
+    blocking: true

--- a/.fiesta/manifest.yaml
+++ b/.fiesta/manifest.yaml
@@ -1,0 +1,18 @@
+# Fiesta tenant contract — M@S (Merch at Scale) identity and references.
+#
+# The harness reads this at the pinned commit and holds no M@S-specific
+# knowledge of its own. Identity ladder: adobe (company) > acom (org) >
+# mas (product) > … . Unknown keys are rejected, so a typo fails loudly.
+org: acom
+product: mas
+repo: antonio-rmrz/mas
+owners_from: CODEOWNERS
+
+# Which shared mental models the planner should consult for M@S work.
+# Selection is tenant-owned; the model content is resolved from the shared
+# registry at run time (see .fiesta/README.md).
+mental_models:
+  use:
+    - mas-web-components
+    - merch-fragments
+    - mas-studio

--- a/.fiesta/preview.yaml
+++ b/.fiesta/preview.yaml
@@ -1,0 +1,14 @@
+# How the harness turns a branch + page into a live preview URL for M@S.
+#
+# M@S runs on Adobe Edge Delivery Services, where any branch is served at
+# `<branch>--mas--<owner>.aem.page`. The visual gate substitutes {branch} and
+# {page} into pin_pattern, then captures screenshots of the result. For this
+# fork the owner is `antonio-rmrz`.
+#
+# Two notes specific to M@S:
+#   - Feature branches must be named `MWPW-XXXXXX` or the IMS auth regex rejects
+#     the preview (see the repo README).
+#   - Live capture of an authenticated surface (e.g. /studio.html) requires IMS
+#     credentials; the component docs pages render without auth.
+mechanism: aem-branch-preview
+pin_pattern: 'https://{branch}--mas--antonio-rmrz.aem.page{page}?martech=off'

--- a/.fiesta/workflows/restyle-component.yaml
+++ b/.fiesta/workflows/restyle-component.yaml
@@ -1,0 +1,20 @@
+# A M@S workflow, composed from the harness capability library.
+#
+# workflow_id is namespaced to `mas.restyle-component` by the harness — do not
+# prefix it here. Each step names a registered handler; steps route by
+# on_success / on_failure to another step id or a terminal (`complete` / `__end__`).
+workflow_id: restyle-component
+name: Restyle a M@S web component
+description: >-
+  Generate a styling change to a web component (or one of its variants) from an
+  issue, then require human sign-off before it proceeds.
+start_step: generate
+steps:
+  - id: generate
+    handler: codegen.generate
+    on_success: approve
+    on_failure: __end__
+  - id: approve
+    handler: mock.approval
+    on_success: complete
+    on_failure: __end__


### PR DESCRIPTION
## Summary

This adds a `.fiesta/` folder that onboards M@S as a tenant of the fiesta automation harness — symmetric to Milo's onboarding. The harness reads these files at the pinned commit and holds no M@S-specific knowledge of its own; everything M@S-specific lives here.

## What's declared

- **`manifest.yaml`** — M@S's identity (`org: acom`, `product: mas`, `repo`) and which shared mental models the planner should consult (`mas-web-components`, `merch-fragments`, `mas-studio`).
- **`gates.yaml`** — M@S's verification gates, mirroring what CI enforces on a web-components PR:
  - `lint` — `npx eslint web-components studio`
  - `format` — `npx prettier --check .`
  - `unit-tests` — `npm test` (the Web Test Runner suite; it also enforces the ≥85% coverage thresholds)
  - `visual` — screenshots a component demo page and routes the evidence to a human
- **`preview.yaml`** — how to turn a branch + page into an Edge Delivery preview URL for the visual gate.
- **`workflows/restyle-component.yaml`** — a web-component restyle workflow composed from the harness's capability handlers.

Unlike Milo, M@S has no separate "structure" gate: test co-location is already enforced by the test runner's file globbing plus the coverage thresholds, so a component without a test fails the unit-tests gate.

## Why

The harness/tenant split means the harness carries zero product knowledge. Declaring M@S's gates, preview scheme, and workflows here means the harness stays generic, and any change M@S wants to make to its own automation is a change in this repo, not in the harness.

## Verification

Ran the harness's real loaders against this folder: the manifest, the `mas.restyle-component` workflow, all four gates (every template resolves), and the preview URL all parse and resolve cleanly.

A repo that declares nothing behaves exactly as before; this folder is purely additive.
